### PR TITLE
Fix readthedocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,8 +13,9 @@ build:
       - poetry config virtualenvs.create false
     post_install:
       # Install dependencies.
+      # https://docs.readthedocs.io/en/stable/build-customization.html
       # https://python-poetry.org/docs/managing-dependencies/#dependency-groups
-      - poetry install --with dev
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with dev
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
Builds are failing despite `cd docs && poetry run make doctest` passing.