### PR TITLE
Can broadcast and python names

### DIFF
--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -96,7 +96,7 @@ The strings in the sequence must be single variable names, with no parentheses o
     >>> bad(randn(3, 4)).shape
     Traceback (most recent call last):
     ...
-    ValueError: Variable name should be made of only ascii letters, got i+1
+    ValueError: Variable name should be a valid python name, got i+1
 
 Disabling Checks
 ----------------

--- a/docs/source/specifying_shapes.rst
+++ b/docs/source/specifying_shapes.rst
@@ -24,9 +24,9 @@ Integers and Variables
 The simplest way to specify a dimension constraint is a literal integer.
 
 Variables can be used to capture dynamic dimensions.
-Variables can be any string of ``[a-zA-Z]+``.
+Variables can be any valid python variable name, defined by the regex ``[^\W\d]\w*``.
 
-For example, the shape spec ``"i 4 inner"`` will match any 3D Tensor where the second dimension is 4, and bind ``i`` to the first dimension and ``inner`` to the last.
+For example, the shape spec ``"i 4 inner_dim"`` will match any 3D Tensor where the second dimension is 4, and bind ``i`` to the first dimension and ``inner`` to the last.
 
 .. doctest::
 
@@ -34,16 +34,16 @@ For example, the shape spec ``"i 4 inner"`` will match any 3D Tensor where the s
     >>> from eincheck import check_shapes
     >>>
     >>> check_shapes(
-    ...     (np.random.randn(3, 4, 5), "i 4 inner"),
+    ...     (np.random.randn(3, 4, 5), "i 4 inner_dim"),
     ... )
-    {'i': 3, 'inner': 5}
+    {'i': 3, 'inner_dim': 5}
     >>> check_shapes(
-    ...     (np.random.randn(3, 4), "i 4 inner"),
+    ...     (np.random.randn(3, 4), "i 4 inner_dim"),
     ... )
     Traceback (most recent call last):
         ...
     ValueError: arg0: expected rank 3, got shape (3, 4)
-      arg0: got (3, 4) expected [i 4 inner]
+      arg0: got (3, 4) expected [i 4 inner_dim]
 
     >>> check_shapes(
     ...     (np.random.randn(3, 4, 5), "i 4 i"),

--- a/eincheck/parser/expressions.py
+++ b/eincheck/parser/expressions.py
@@ -1,5 +1,5 @@
 import operator
-import string
+import re
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Collection, Dict, Generic, Set, Tuple, TypeVar
 
@@ -48,13 +48,13 @@ class Literal(Expr):
 
 
 class Variable(Expr):
+    NAME_REGEX = re.compile(r"[^\W\d]\w*")
+
     def __init__(self, x: str):
         if not x:
             raise ValueError("Variable name must not be empty")
-        if not (set(x) <= set(string.ascii_letters)):
-            raise ValueError(
-                f"Variable name should be made of only ascii letters, got {x}"
-            )
+        if not self.NAME_REGEX.fullmatch(x):
+            raise ValueError(f"Variable name should be a valid python name, got {x}")
         self.x = str(x)
 
     def __str__(self) -> str:

--- a/eincheck/parser/grammar.py
+++ b/eincheck/parser/grammar.py
@@ -27,7 +27,7 @@ shape : can_broadcast_dim? (" "+ can_broadcast_dim)*
       | "_" -> underscore
 
 ?value_expr : INT   -> int
-            | WORD  -> word
+            | NAME  -> word
             | math
 
 ?can_broadcast_dim : dim "!" -> can_broadcast
@@ -46,8 +46,7 @@ shape : can_broadcast_dim? (" "+ can_broadcast_dim)*
       | "(" " "* value_expr " "* ")"
 
 %import common.INT
-%import common.WORD
-%import common.WS
+%import python.NAME
 """
 
 _parser = Lark(grammar, start="shape")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eincheck"
-version = "0.4.0"
+version = "0.5.0"
 description = "Tensor shape checks inspired by einstein notation"
 authors = ["Ethan Pronovost <epronovo1@gmail.com>"]
 readme = "README.md"

--- a/tests/checks/shapes_test.py
+++ b/tests/checks/shapes_test.py
@@ -157,6 +157,29 @@ TEST_CASES = [
         error="arg0: $ should not be present in the shape spec for a Tensor, "
         "got [i $ j]",
     ),
+    _TestCase(
+        [((2, 3), "i j!"), ((2, 1), "i j!")],
+        in_bindings={"j": 3},
+        out_bindings={"i": 2, "j": 3},
+    ),
+    _TestCase(
+        [((2, 3), "i *j!"), ((2, 1), "i *j!")],
+        in_bindings={"j": (3,)},
+        out_bindings={"i": 2, "j": (3,)},
+    ),
+    _TestCase(
+        [((2, 3), "*i!"), ((2, 1), "*i!"), ((1, 3), "*i!"), ((1, 1), "*i!")],
+        in_bindings={"i": (2, 3)},
+        out_bindings={"i": (2, 3)},
+    ),
+    _TestCase(
+        [((2, 4), "i (j+1)!"), ((2, 1), "i (j+1)!")],
+        in_bindings={"j": 3},
+        out_bindings={"i": 2, "j": 3},
+    ),
+    _TestCase(
+        [((2, 3), "i i!")], error="arg0 dim 1: expected can broadcast to i=2 got 3"
+    ),
 ]
 
 

--- a/tests/parser/grammar_test.py
+++ b/tests/parser/grammar_test.py
@@ -64,6 +64,11 @@ TEST_CASES = [
             DimSpec(None),
         ],
     ),
+    ("7!", [DimSpec.create_literal(7).make_can_broadcast()]),
+    ("42*!", [DimSpec.create_literal(42).make_repeated().make_can_broadcast()]),
+    ("x!", [DimSpec.create_variable("x").make_can_broadcast()]),
+    ("*y!", [DimSpec.create_variable("y").make_variadic().make_can_broadcast()]),
+    ("z*!", [DimSpec.create_variable("z").make_repeated().make_can_broadcast()]),
 ]
 
 

--- a/tests/parser/grammar_test.py
+++ b/tests/parser/grammar_test.py
@@ -17,6 +17,8 @@ def _simple_test_case(s: str) -> Tuple[ShapeArg, List[DimSpec]]:
 TEST_CASES = [
     _simple_test_case("i j Hello World i I"),
     _simple_test_case("i 2  1 42 HELLO  ii"),
+    _simple_test_case("a1 a2 a3"),
+    _simple_test_case("name_with_underscores Name_With_Underscores"),
     ("...", [DimSpec(None, DimType.REPEATED)]),
     (
         "5 ...  k",
@@ -91,8 +93,8 @@ BAD_ARGS: List[Tuple[ShapeArg, Optional[str]]] = [
     ("i $", None),
     ("... 2+1", None),
     ("i$", None),
-    (["i%"], "Variable name should be made of only ascii letters, got i%"),
-    (["2.0"], "Variable name should be made of only ascii letters, got 2.0"),
+    (["i%"], "Variable name should be a valid python name, got i%"),
+    (["2.0"], "Variable name should be a valid python name, got 2.0"),
     ([""], "Variable name must not be empty"),
     ([3.2], "Unexpected type: float"),  # type: ignore[list-item]
 ]

--- a/tests/parser/shape_spec_test.py
+++ b/tests/parser/shape_spec_test.py
@@ -9,3 +9,6 @@ def test_is_checkable() -> None:
     assert not create_shape_spec("i *j k*").is_checkable(dict(i=2))
     assert not create_shape_spec("i *j k*").is_checkable(dict(i=4, k=2))
     assert create_shape_spec("i *j k*").is_checkable(dict(j=(2, 3)))
+    assert not create_shape_spec("i!").is_checkable({})
+    assert create_shape_spec("i!").is_checkable(dict(i=7))
+    assert not create_shape_spec("(i+1)!").is_checkable({})


### PR DESCRIPTION
Two updates to the shape spec grammar:

1. Can broadcast
Adds a new syntax `!` which means "match any shape that can broadcast to this". For example, if `x=2` and `y=(3, 4)`, then

| Shape spec | Shapes it matches |
| --- | --- |
| `"x 5"` | (2, 5) |
| `"x! 5"` | (2, 5), (1, 5) |
| `"*y 7"` | (3, 4, 7) |
| `"*y! 7"` | (3, 4, 7), (3, 1, 7), (1, 4, 7), (1, 1, 7) |

2. Python names

Previously, variable names could only contain ascii letters `[a-zA-Z]+`.
The grammar now allows any valid python name `[^\W\d]\w*`.
Concretely, this means that variable names can now include digits and underscores in addition to ascii letters(but the first character cannot be a digit).
Examples of variable names that are now allowed: `"a1 a2 a3"`, `"*batch_dims 7"`.