### PR TITLE
Scalars

### DIFF
--- a/docs/source/specifying_shapes.rst
+++ b/docs/source/specifying_shapes.rst
@@ -11,6 +11,7 @@ The following sections describe this syntax.
 
     "``2``, ``i``", ":ref:`Integers and Variables`"
     "``(2 * x)``", ":ref:`Expressions`"
+    "``.``", ":ref:`Scalars`"
     "``a*``", ":ref:`Repeated Dimension Constraints`"
     "``*n``", ":ref:`Variadic Dimension Constraints`"
     "``_``, ``...``", ":ref:`Underscores and Ellipses`"
@@ -87,6 +88,25 @@ For example,
     {'n': 3, 'x': 5, 'y': 7}
     >>> check_shapes((x, "n ((2 * n) - 1)"))
     {'n': 3}
+
+Scalars
+-------
+A ``.`` can be used to specify a scalar (i.e. ``shape = ()``).
+
+.. doctest::
+
+    >>> import numpy as np
+    >>> from eincheck import check_shapes
+    >>>
+    >>> check_shapes((np.array(1.0), "."))
+    {}
+    >>> check_shapes((np.array([1.0]), "."))
+    Traceback (most recent call last):
+        ...
+    ValueError: arg0: expected rank 0, got shape (1,)
+      arg0: got (1,) expected []
+
+
 
 Repeated Dimension Constraints
 ------------------------------

--- a/eincheck/parser/grammar.py
+++ b/eincheck/parser/grammar.py
@@ -22,6 +22,7 @@ grammar = r"""
 
 shape : can_broadcast_dim? (" "+ can_broadcast_dim)*
       | "$" -> dollar
+      | "." -> scalar
 
 ?expr : value_expr
       | "_" -> underscore
@@ -107,6 +108,9 @@ class TreeToSpec(Transformer):  # type: ignore[type-arg]
 
     def dollar(self, s: Any) -> ShapeSpec:
         return ShapeSpec([DimSpec(DataExpr())])
+
+    def scalar(self, s: Any) -> ShapeSpec:
+        return ShapeSpec([])
 
     @staticmethod
     def _get_expr(x: Any) -> Expr:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eincheck"
-version = "0.5.1"
+version = "0.6.0"
 description = "Tensor shape checks inspired by einstein notation"
 authors = ["Ethan Pronovost <epronovo1@gmail.com>"]
 readme = "README.md"

--- a/tests/checks/func_test.py
+++ b/tests/checks/func_test.py
@@ -460,3 +460,16 @@ def test_output_optional(mode: DecoratorMode) -> None:
 
     foo(arr(8))
     foo(arr(9))
+
+
+def test_scalar_input_output(mode: DecoratorMode) -> None:
+    @mode.str_decorator("., . -> ., .")
+    def foo(x: Any, y: Any) -> Tuple[Any, Any]:
+        if y == 0:
+            return x + y, x * y.reshape(1, 1)
+        return x + y, x * y
+
+    foo(arr(), arr())
+
+    with raises_literal("output1: expected rank 0, got shape (1, 1)"):
+        foo(arr(), np.array(0.0))

--- a/tests/checks/shapes_test.py
+++ b/tests/checks/shapes_test.py
@@ -186,6 +186,8 @@ TEST_CASES = [
     _TestCase(
         [((3, 4), "3 n!")], error="Unable to check: [arg0] missing variables: [n]"
     ),
+    _TestCase([((), ".")]),
+    _TestCase([((3,), ".")], error="arg0: expected rank 0, got shape (3,)"),
 ]
 
 

--- a/tests/parser/grammar_test.py
+++ b/tests/parser/grammar_test.py
@@ -71,6 +71,7 @@ TEST_CASES = [
     ("x!", [DimSpec.create_variable("x").make_can_broadcast()]),
     ("*y!", [DimSpec.create_variable("y").make_variadic().make_can_broadcast()]),
     ("z*!", [DimSpec.create_variable("z").make_repeated().make_can_broadcast()]),
+    (".", []),
 ]
 
 

--- a/tests/parser/shape_spec_test.py
+++ b/tests/parser/shape_spec_test.py
@@ -12,3 +12,4 @@ def test_is_checkable() -> None:
     assert not create_shape_spec("i!").is_checkable({})
     assert create_shape_spec("i!").is_checkable(dict(i=7))
     assert not create_shape_spec("(i+1)!").is_checkable({})
+    assert create_shape_spec(".").is_checkable({})


### PR DESCRIPTION
Adds `.` syntax for scalar tensors.

e.g.
```
@eincheck.check_func("d, d -> .")
def dot_product(x, y):
    return (x * y).sum()
```