### PR TITLE
Support scalar and lower-rank shapes in variadic broadcast (*x!)

### DIFF
--- a/docs/source/specifying_shapes.rst
+++ b/docs/source/specifying_shapes.rst
@@ -245,6 +245,11 @@ A dimension constraint with an ``!`` following it will match anything that can b
 For example, if ``i=3`` then ``i!`` will match a dimension of either ``3`` or ``1``.
 Similarly, if ``j=(2, 3)`` then ``*j!`` will match shapes of ``(2, 3)``, ``(2, 1)``, ``(1, 3)``, or ``(1, 1)``.
 
+For variadic broadcast constraints (``*j!``), shapes with fewer dimensions are also accepted,
+following `numpy broadcasting rules <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_
+where missing leading dimensions are treated as 1.
+This means ``*j!`` with ``j=(2, 3)`` will also match ``(3,)`` (equivalent to ``(1, 3)``), ``(1,)``, and ``()`` (a scalar).
+
 .. doctest::
 
     >>> from numpy.random import randn
@@ -267,6 +272,14 @@ Similarly, if ``j=(2, 3)`` then ``*j!`` will match shapes of ``(2, 3)``, ``(2, 1
     ...     (randn(1, 3), "*j!"),
     ...     (randn(2, 1), "*j!"),
     ...     (randn(1, 1), "*j!"),
+    ... )
+    {'j': (2, 3)}
+    >>> import numpy as np
+    >>> check_shapes(
+    ...     (randn(2, 3), "*j"),
+    ...     (randn(3,), "*j!"),
+    ...     (randn(1,), "*j!"),
+    ...     (np.array(1.0), "*j!"),
     ... )
     {'j': (2, 3)}
     >>> check_shapes(

--- a/eincheck/checks/shapes.py
+++ b/eincheck/checks/shapes.py
@@ -10,6 +10,16 @@ from eincheck.types import ShapeVariable, Tensor
 from eincheck.utils import get_shape
 
 
+def _is_broadcast_compatible(got: Tuple[int, ...], expected: Tuple[int, ...]) -> bool:
+    """Check if got is broadcast-compatible with expected (numpy-style).
+
+    A shorter got is allowed: missing leading dims are implicitly 1.
+    """
+    if len(got) > len(expected):
+        return False
+    return all(g == e or g == 1 for g, e in zip(reversed(got), reversed(expected)))
+
+
 def _check_dim_spec(
     got_shape: Tuple[int, ...],
     d: DimSpec,
@@ -44,9 +54,18 @@ def _check_dim_spec(
         )
 
     def do_check(g: ShapeVariable, indices: ShapeVariable) -> None:
-        if d.can_broadcast and g not in broadcast_values:
-            first_line = f"expected can broadcast to {d.value}={expected_value} got {g}"
-        elif not d.can_broadcast and g != expected_value:
+        if d.can_broadcast:
+            if isinstance(g, tuple) and isinstance(expected_value, tuple):
+                is_ok = _is_broadcast_compatible(g, expected_value)
+            else:
+                is_ok = g in broadcast_values
+            if not is_ok:
+                first_line = (
+                    f"expected can broadcast to {d.value}={expected_value} got {g}"
+                )
+            else:
+                first_line = None
+        elif g != expected_value:
             first_line = f"expected {d.value}={expected_value} got {g}"
         else:
             first_line = None

--- a/eincheck/parser/dim_spec.py
+++ b/eincheck/parser/dim_spec.py
@@ -105,6 +105,8 @@ class DimSpec:
             return 1
         if self.type is DimType.REPEATED:
             return None
+        if self.can_broadcast:
+            return None
 
         if self.value is not None and self.is_defined(bindings):
             got = self.value.eval(bindings)

--- a/tests/checks/shapes_test.py
+++ b/tests/checks/shapes_test.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Sequence, Tuple
 
 import pytest
 
-from eincheck.checks.shapes import check_shapes
+from eincheck.checks.shapes import _is_broadcast_compatible, check_shapes
 from eincheck.parser.dim_spec import DimSpec
 from eincheck.parser.grammar import ShapeArg
 from eincheck.types import ShapeVariable
@@ -197,6 +197,10 @@ TEST_CASES = [
         error="arg1 dims (1,): expected can broadcast to j=(2, 3) got (5,)",
     ),
     _TestCase(
+        [((3,), "*j"), ((1, 3), "*j!")],
+        error="arg1 dims (0, 1): expected can broadcast to j=(3,) got (1, 3)",
+    ),
+    _TestCase(
         [((2, 4), "i (j+1)!"), ((2, 1), "i (j+1)!")],
         in_bindings={"j": 3},
         out_bindings={"i": 2, "j": 3},
@@ -213,6 +217,17 @@ TEST_CASES = [
     _TestCase([((), ".")]),
     _TestCase([((3,), ".")], error="arg0: expected rank 0, got shape (3,)"),
 ]
+
+
+def test_is_broadcast_compatible() -> None:
+    assert _is_broadcast_compatible((), (2, 3))
+    assert _is_broadcast_compatible((3,), (2, 3))
+    assert _is_broadcast_compatible((1,), (2, 3))
+    assert _is_broadcast_compatible((2, 3), (2, 3))
+    assert _is_broadcast_compatible((1, 1), (2, 3))
+    assert not _is_broadcast_compatible((5,), (2, 3))
+    assert not _is_broadcast_compatible((1, 4), (2, 3))
+    assert not _is_broadcast_compatible((1, 2, 3), (2, 3))
 
 
 @pytest.mark.parametrize("case", TEST_CASES)

--- a/tests/checks/shapes_test.py
+++ b/tests/checks/shapes_test.py
@@ -173,6 +173,30 @@ TEST_CASES = [
         out_bindings={"i": (2, 3)},
     ),
     _TestCase(
+        [((2, 3), "*i"), ((1, 1), "*i!"), ((), "*i!")],
+        out_bindings={"i": (2, 3)},
+    ),
+    _TestCase(
+        [((2, 3), "*i"), ((3,), "*i!"), ((), "*i!")],
+        out_bindings={"i": (2, 3)},
+    ),
+    _TestCase(
+        [((2, 3), "*i"), ((5,), "*i!")],
+        error="arg1 dims (0,): expected can broadcast to i=(2, 3) got (5,)",
+    ),
+    _TestCase(
+        [((2, 3), "*i"), ((1, 4), "*i!")],
+        error="arg1 dims (0, 1): expected can broadcast to i=(2, 3) got (1, 4)",
+    ),
+    _TestCase(
+        [((5, 2, 3), "i *j"), ((5,), "i *j!"), ((5, 3), "i *j!"), ((5, 1), "i *j!")],
+        out_bindings={"i": 5, "j": (2, 3)},
+    ),
+    _TestCase(
+        [((5, 2, 3), "i *j"), ((5, 5), "i *j!")],
+        error="arg1 dims (1,): expected can broadcast to j=(2, 3) got (5,)",
+    ),
+    _TestCase(
         [((2, 4), "i (j+1)!"), ((2, 1), "i (j+1)!")],
         in_bindings={"j": 3},
         out_bindings={"i": 2, "j": 3},


### PR DESCRIPTION
First of all, awesome library!

For the PR, note that the `n_dims` change (returning `None` for broadcast variadics) means `*j!` can no longer coexist with another flexible-size dim (like `...`, `k*`, or unbound `*k`) in the same spec. Previously, bound `*j!` returned a fixed `n_dims`, so e.g. `"*j! ..."` would resolve unambiguously. This was not tested or documented, but it did work. With lower-rank support this becomes inherently ambiguous, so it's an acceptable trade-off -- just worth calling out as a known behavioral change.

One could make this explicit:
```
    _TestCase(
        [((2, 1, 5, 6), "*j! ...")],
        in_bindings={"j": (2, 3)},
        error="Unable to determine bindings for: arg0",
    ),
```