### PR TITLE
Fix grammar handling of underscore

### DIFF
--- a/eincheck/parser/grammar.py
+++ b/eincheck/parser/grammar.py
@@ -24,8 +24,8 @@ shape : can_broadcast_dim? (" "+ can_broadcast_dim)*
       | "$" -> dollar
       | "." -> scalar
 
-?expr : value_expr
-      | "_" -> underscore
+?expr : "_" -> underscore
+      | value_expr
 
 ?value_expr : INT   -> int
             | NAME  -> word

--- a/poetry.lock
+++ b/poetry.lock
@@ -1108,4 +1108,4 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8.1,<4"
-content-hash = "aa817df1172043867247d86c41197157b9bcecd585bb14fed386a5f57997b3eb"
+content-hash = "88e70877efcf4a06b2077f6348494e6de1c54cfe89d1a9d679a8df797ae017f9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -478,14 +478,14 @@ i18n = ["Babel (>=2.7)"]
 
 [[package]]
 name = "lark"
-version = "1.1.9"
+version = "1.3.1"
 description = "a modern parsing library"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "lark-1.1.9-py3-none-any.whl", hash = "sha256:a0dd3a87289f8ccbb325901e4222e723e7d745dbfc1803eaf5f3d2ace19cf2db"},
-    {file = "lark-1.1.9.tar.gz", hash = "sha256:15fa5236490824c2c4aba0e22d2d6d823575dcaf4cdd1848e34b6ad836240fba"},
+    {file = "lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12"},
+    {file = "lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905"},
 ]
 
 [package.extras]
@@ -1108,4 +1108,4 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.8.1,<4"
-content-hash = "88e70877efcf4a06b2077f6348494e6de1c54cfe89d1a9d679a8df797ae017f9"
+content-hash = "aa817df1172043867247d86c41197157b9bcecd585bb14fed386a5f57997b3eb"


### PR DESCRIPTION
With the previous code under a newer version of lark (1.3.1), "_" was parsing as `expr -> value_expr -> word`. This didn't happen under lark 1.1.1. This fixes it.